### PR TITLE
Operadores de identidade

### DIFF
--- a/00 - Fundamentos/operadores_identidade.py
+++ b/00 - Fundamentos/operadores_identidade.py
@@ -1,5 +1,5 @@
-saldo = 1000
-limite = 1000
+saldo = None
+limite = None
 
 print(saldo is limite)
 print(saldo is not limite)

--- a/operadores_de_identidade.md
+++ b/operadores_de_identidade.md
@@ -1,0 +1,56 @@
+
+# Operadores de Identidade em Python
+
+Os operadores de identidade no Python são usados para comparar as identidades dos objetos. No Python, cada objeto tem uma identidade, um tipo e um valor. A identidade de um objeto é como um endereço de memória e é única para cada objeto durante sua vida útil. Os operadores de identidade permitem verificar se dois objetos ocupam a mesma localização na memória. São eles:
+
+1. `is`: Retorna `True` se duas variáveis apontam para o mesmo objeto.
+2. `is not`: Retorna `True` se duas variáveis não apontam para o mesmo objeto.
+
+## Exemplos de Uso
+
+```python
+a = [1, 2, 3]
+b = a       # b é o mesmo objeto que a
+c = [1, 2, 3]  # c é um objeto diferente com o mesmo conteúdo que a
+
+# Usando 'is'
+print(a is b)  # True, porque a e b são o mesmo objeto
+print(a is c)  # False, porque a e c não são o mesmo objeto, apesar de terem o mesmo conteúdo
+
+# Usando 'is not'
+print(a is not b)  # False
+print(a is not c)  # True
+```
+
+## Comparação de Identidade vs. Igualdade
+
+- O operador `is` é diferente do operador `==`. O `is` verifica se duas variáveis apontam para o mesmo objeto (mesma identidade), enquanto `==` verifica se os valores dos objetos são iguais.
+
+```python
+a = [1, 2, 3]
+b = [1, 2, 3]
+
+print(a is b)    # False, pois a e b são objetos diferentes
+print(a == b)    # True, pois a e b têm o mesmo conteúdo
+```
+
+## Uso com Singleton
+
+- Os operadores de identidade são frequentemente usados para comparar com singletons, como `None`.
+
+```python
+x = None
+y = None
+
+print(x is None)  # True
+print(x is y)     # True, pois ambos x e y apontam para o mesmo objeto None
+```
+
+## Cuidados 
+
+- Deve-se ter cuidado ao usar `is` para comparar objetos imutáveis (como strings e números inteiros) devido ao cache interno do Python para esses objetos. Em alguns casos, objetos imutáveis com o mesmo valor podem acabar tendo a mesma identidade na memória, mas isso não é garantido e pode variar dependendo da implementação e da versão do Python.
+
+## Boas Práticas
+
+- Use `is` e `is not` primariamente para comparar com singletons (como `None`).
+- Prefira `==` e `!=` para verificar igualdade de valores entre objetos, a menos que seja necessário comparar identidades.


### PR DESCRIPTION
### Colaboração para a trilha 

- Altera o exemplo da aula de operadores de identidade, mudando a verificação de identidade das variáveis que antes apontavam  para o objeto imutável inteiro 1000 e agora apontam para o Singleton `None` .

- Adiciona arquivo `operadores_de_identidade.md`  que traz uma breve documentação a respeito dos operadores de identidade.