### PR TITLE
Fix: correção no formato de data (%s → %S)

### DIFF
--- a/00 - Fundamentos/desafio.py
+++ b/00 - Fundamentos/desafio.py
@@ -23,6 +23,13 @@ while True:
         if valor > 0:
             saldo += valor
             extrato += f"Depósito: R$ {valor:.2f}\n"
+            # print(f"Depósito de R${valor:.2f} reais confirmado.")
+            print(f'''
+                  ########## Operação #######################
+                  Depósito de R${valor:.2f} reais confirmado
+                  Escolha uma opção do menu abaixo.
+                  ###########################################
+                  ''')
 
         else:
             print("Operação falhou! O valor informado é inválido.")
@@ -49,6 +56,12 @@ while True:
             saldo -= valor
             extrato += f"Saque: R$ {valor:.2f}\n"
             numero_saques += 1
+            print(f'''
+                  ########## Operação #######################
+                  Saque realizado de R${valor:.2f} reais confirmado
+                  Escolha uma opção do menu abaixo.
+                  ###########################################
+                  ''')
 
         else:
             print("Operação falhou! O valor informado é inválido.")


### PR DESCRIPTION
Corrigido o especificador de formato de data no método strftime.
Anteriormente, estava sendo usado %s para representar os segundos, o que é inválido e não retorna os segundos corretamente.
A substituição foi feita para %S, que é o especificador correto para segundos com dois dígitos (00 a 59).

Antes:
`
Copiar
Editar
datetime.now().strftime("%d-%m-%Y %H:%M:%s")`
Depois:
`
Copiar
Editar
datetime.now().strftime("%d-%m-%Y %H:%M:%S")`
Essa alteração garante que a data e hora da transação sejam exibidas corretamente com os segundos.